### PR TITLE
Make link to learning path more friendly in innersource

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -10,7 +10,7 @@ before:
   body: 00_welcome.md
 - type: updateBranchProtection
 
-# Course artifacts
+# Course artifacts:
 # 1. Issue: Welcome
 # 2. PR: Repository ownership and names
 # 3. PR: Create discoverable repos

--- a/config.yml
+++ b/config.yml
@@ -10,7 +10,7 @@ before:
   body: 00_welcome.md
 - type: updateBranchProtection
 
-# Course artifacts:
+# Course artifacts
 # 1. Issue: Welcome
 # 2. PR: Repository ownership and names
 # 3. PR: Create discoverable repos

--- a/config.yml
+++ b/config.yml
@@ -231,6 +231,5 @@ steps:
     with: 14_congratulations.md
     data:
       deploymentURL: '%actions.pagesUrl.data.html_url%'
-      learningPathURL: 'https://lab.github.com/githubtraining/paths/innersource:-theory-to-practice'
       forkURL: '%payload.repository.html_url%/fork'
       downloadURL: '%payload.repository.html_url%/archive/master.zip'

--- a/responses/14_congratulations.md
+++ b/responses/14_congratulations.md
@@ -14,4 +14,4 @@ You finished this course. You can see a deployed version of our work together at
 
 I won't track any further events in this repository.
 
-Your next steps are in the [Innersource learning path]({{ GHE_HOST }}/{{ course.Owner.login }}/paths/innersource:-theory-to-practice).
+Your next steps are in the [Innersource learning path]({{ GITHUB_URL }}/{{ course.Owner.login }}/paths/innersource:-theory-to-practice).

--- a/responses/14_congratulations.md
+++ b/responses/14_congratulations.md
@@ -14,4 +14,4 @@ You finished this course. You can see a deployed version of our work together at
 
 I won't track any further events in this repository.
 
-Your next steps are in the [Innersource learning path]({{ learningPathURL }}).
+Your next steps are in the [Innersource learning path]({{ GHE_HOST }}/{{ owner }}/paths/innersource:-theory-to-practice).

--- a/responses/14_congratulations.md
+++ b/responses/14_congratulations.md
@@ -14,4 +14,4 @@ You finished this course. You can see a deployed version of our work together at
 
 I won't track any further events in this repository.
 
-Your next steps are in the [Innersource learning path]({{ GHE_HOST }}/{{ owner }}/paths/innersource:-theory-to-practice).
+Your next steps are in the [Innersource learning path]({{ GHE_HOST }}/{{ course.Owner.login }}/paths/innersource:-theory-to-practice).


### PR DESCRIPTION
This resolves #29 by using [variables](https://lab.github.com/docs/writing-responses) instead of a hard-coded link to the InnerSource path.

I am going to deploy this branch and test, verifying it still works on GitHub.com. @amyschoen is there a way you could test this solution on GHE while this change is still on a branch?